### PR TITLE
Fix warnings

### DIFF
--- a/js/Store/SeqFeature/RDSegmentation.js
+++ b/js/Store/SeqFeature/RDSegmentation.js
@@ -19,7 +19,7 @@ function getSD(data) {
     data.reduce(function (sq, n) {
       return sq + (n - m) * (n - m);
     }, 0) /
-      (data.length - 1),
+      (data.length - 1)
   );
 }
 
@@ -74,7 +74,7 @@ define([
       }
       const text = await result.text();
       const refs = {};
-      text.split("\n").forEach(row => {
+      text.split("\n").forEach((row) => {
         if (row.trim() !== "") {
           const [refName, start, gcContent, gcCount, atCount] = row.split("\t");
           if (!refs[refName]) {
@@ -110,7 +110,7 @@ define([
       } else {
         const { mean, sd, gcRD } = await this.getAvgAndSD(
           this.fileBlob,
-          this.sample,
+          this.sample
         );
         globalCache.set(`${this.fileBlob}`, { mean, sd, gcRD });
         // console.log("calculated global chr mean,sd", mean);
@@ -121,7 +121,7 @@ define([
       }
 
       const regularizedReferenceName = this.browser.regularizeReferenceName(
-        query.ref,
+        query.ref
       );
 
       // let binSize = 100000;
@@ -157,7 +157,7 @@ define([
           bins[featureBin].sum_score += finalScore;
           bins[featureBin].count++;
           bins[featureBin].source = sampleName;
-        },
+        }
       );
 
       var avgbin = [];
@@ -177,7 +177,7 @@ define([
           if (bins[j]) {
             const featureBin = Math.max(
               Math.floor(bins[j].start / (binSize * binFactor)),
-              0,
+              0
             );
 
             avgbin[k].start = featureBin * binSize * binFactor;
@@ -193,12 +193,12 @@ define([
       bins = [];
       bins = avgbin;
 
-      bins.forEach(sample => {
+      bins.forEach((sample) => {
         sample.bin_score = sample.bin_score;
         const start = sample.start;
         const featureBin = Math.max(
           Math.floor(start / (binSize * binFactor)),
-          0,
+          0
         );
 
         const gcVal = chrGc[featureBin] ? chrGc[featureBin].gcContent : 0;
@@ -226,12 +226,12 @@ define([
       query,
       featureCallback,
       finishedCallback,
-      errorCallback,
+      errorCallback
     ) {
       try {
         const { bins, average } = await this.featureCache.get(query.ref, query);
 
-        bins.forEach(feature => {
+        bins.forEach((feature) => {
           if (feature.end > query.start && feature.start < query.end) {
             const sample = feature;
             featureCallback(
@@ -240,7 +240,7 @@ define([
                   score: sample.bin_score,
                   source: "sample",
                 }),
-              }),
+              })
             ),
               featureCallback(
                 new SimpleFeature({
@@ -248,7 +248,7 @@ define([
                     score: sample.gc_corrected,
                     source: "sample_GC",
                   }),
-                }),
+                })
               ),
               featureCallback(
                 new SimpleFeature({
@@ -256,7 +256,7 @@ define([
                     score: sample.corrected_mean,
                     source: "sample_meanshift",
                   }),
-                }),
+                })
               ),
               featureCallback(
                 new SimpleFeature({
@@ -264,7 +264,7 @@ define([
                     score: sample.call_score,
                     source: "sample_call",
                   }),
-                }),
+                })
               );
           }
         });
@@ -283,14 +283,19 @@ define([
       const parser = await this.getParser();
       const samples = parser.samples;
 
-      const results = await blob.readFile("utf8");
+      const results = await blob.readFile();
       const textDecoder = new TextDecoder("utf-8");
       const buffer = await unzip(results);
+      if (buffer.length > 500000000) {
+        throw new Error(
+          "Buffer to big to process by this program at this time. We are working on line-by-line buffering. Please email us for more information"
+        );
+      }
       const lines = textDecoder.decode(buffer);
       let scores = [];
       let chrbin_score = [];
       let feature_score = [];
-      lines.split("\n").forEach(line => {
+      lines.split("\n").forEach((line) => {
         if (line.startsWith("#") || line == "") {
           return;
         }
@@ -361,7 +366,7 @@ define([
       // console.log(fit_info.fit_data());
       // console.log(gcContent);
       for (const gc in gcContent) {
-        var raw_gc = gcContent[gc].filter(x => x > 0 && x < max_rd);
+        var raw_gc = gcContent[gc].filter((x) => x > 0 && x < max_rd);
         //console.log(gc, gcContent[gc]);
         //console.log(raw_gc);
         //const gcMean = getMean(gcContent[gc]);
@@ -375,11 +380,11 @@ define([
       for (const chr in bins) {
         let chrGC = gc[chr];
         //console.log(chr, chrGC);
-        bins[chr].forEach(sample => {
+        bins[chr].forEach((sample) => {
           const start = sample.start;
           const featureBin = Math.max(
             Math.floor(start / (binSize * binFactor)),
-            0,
+            0
           );
           const gcVal = chrGC[featureBin] ? chrGC[featureBin].gcContent : 0;
 

--- a/js/View/Dialog/cnvpytor_rd_baf.js
+++ b/js/View/Dialog/cnvpytor_rd_baf.js
@@ -27,7 +27,7 @@ define([
   dijitFocus,
   FileBlob,
   XHRBlob,
-  BlobFilehandleWrapper,
+  BlobFilehandleWrapper
 ) {
   return declare(null, {
     constructor: function (args) {
@@ -50,19 +50,19 @@ define([
       var subcontainer = dojo.create(
         "div",
         { style: { padding: "20px" } },
-        container,
+        container
       );
 
       const flex = dojo.create(
         "div",
         { style: { display: "flex", border: "1px solid black" } },
-        subcontainer,
+        subcontainer
       );
       const panel1 = dojo.create("div", { style: { padding: "10px" } }, flex);
       dojo.create(
         "p",
         { innerHTML: "Option 1: URL for a VCF.gz file (tabixed VCF)" },
-        panel1,
+        panel1
       );
 
       var searchBox = new TextBox().placeAt(panel1);
@@ -73,15 +73,14 @@ define([
           innerHTML:
             "Option 2: Open VCF.gz and VCF.gz.tbi file from local computer",
         },
-        panel2,
+        panel2
       );
 
       var fileBox = dojo.create(
         "input",
         { type: "file", multiple: "multiple" },
-        panel2,
+        panel2
       );
-
 
       this.searchBox = searchBox;
       this.fileBox = fileBox;
@@ -93,14 +92,17 @@ define([
       // Reference genome set
       const flex3 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "2px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "2px" } },
+        subcontainer
       );
       const panel3 = dojo.create("div", { style: { padding: "1px" } }, flex3);
       dojo.create(
         "span",
-        { innerHTML: "Reference genome (used to calibrate GC):", style: {margin: "0 5px 0 0"}},
-        panel3,
+        {
+          innerHTML: "Reference genome (used to calibrate GC):",
+          style: { margin: "0 5px 0 0" },
+        },
+        panel3
       );
 
       new Select({
@@ -115,29 +117,29 @@ define([
       // Select sample
       const flex4 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel4 = dojo.create("div", { style: { padding: "1px" } }, flex4);
 
       dojo.create(
         "snan",
-        { innerHTML: "Sample index", style: {margin: "0 5px 0 0"} },
-        panel4,
+        { innerHTML: "Sample index", style: { margin: "0 5px 0 0" } },
+        panel4
       );
       var sampleIndex = new TextBox({ value: 0, width: "5em" }).placeAt(panel4);
 
       dojo.create(
         "snan",
-        { innerHTML: "or ", style: {margin: "0 5px 0 5px"} },
-        panel4,
+        { innerHTML: "or ", style: { margin: "0 5px 0 5px" } },
+        panel4
       );
 
       // select sample panel
       const flex5 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel5 = dojo.create("div", { style: { padding: "1px" } }, flex5);
 
@@ -147,12 +149,16 @@ define([
           let tabixFile;
           if (this.searchBox.value) {
             tabixFile = new TabixIndexedFile({
-              filehandle: new XHRBlob(this.searchBox.value, {
-                expectRanges: true,
-              }),
-              tbiFilehandle: new XHRBlob(this.searchBox.value + ".tbi", {
-                expectRanges: true,
-              }),
+              filehandle: new BlobFilehandleWrapper(
+                new XHRBlob(this.searchBox.value, {
+                  expectRanges: true,
+                })
+              ),
+              tbiFilehandle: new BlobFilehandleWrapper(
+                new XHRBlob(this.searchBox.value + ".tbi", {
+                  expectRanges: true,
+                })
+              ),
             });
           } else if (this.fileBox.files.length) {
             let tbi = 0;
@@ -168,20 +174,21 @@ define([
             }
             tabixFile = new TabixIndexedFile({
               filehandle: new BlobFilehandleWrapper(
-                new FileBlob(this.fileBox.files[vcf]),
+                new FileBlob(this.fileBox.files[vcf])
               ),
               tbiFilehandle: new BlobFilehandleWrapper(
-                new FileBlob(this.fileBox.files[tbi]),
+                new FileBlob(this.fileBox.files[tbi])
               ),
             });
           }
 
           if (tabixFile) {
             let vcfParser = new VCF({ header: await tabixFile.getHeader() });
+            panel5.innerHTML = "";
             dojo.create(
               "span",
-              { innerHTML: "Select sample:", style: {margin: "0 5px 0 0"}},
-              panel5,
+              { innerHTML: "Select sample:", style: { margin: "0 5px 0 0" } },
+              panel5
             );
 
             this.sampleSelectBox = new Select({
@@ -200,31 +207,34 @@ define([
 
       const flex6 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel6 = dojo.create("div", { style: { padding: "1px" } }, flex6);
       dojo.create(
         "snan",
-        { innerHTML: "Bin Size", style: {margin: "0 5px 0 0"} },
-        panel6,
+        { innerHTML: "Bin Size", style: { margin: "0 5px 0 0" } },
+        panel6
       );
-      var binSize = new TextBox({ value: 100000, width: "5em" }).placeAt(panel6);
-      
+      var binSize = new TextBox({ value: 100000, width: "5em" }).placeAt(
+        panel6
+      );
 
-      // Default Track name 
+      // Default Track name
       const flex7 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel7 = dojo.create("div", { style: { padding: "1px" } }, flex7);
       dojo.create(
         "snan",
-        { innerHTML: "Track Name", style: {margin: "0 5px 0 0"} },
-        panel7,
+        { innerHTML: "Track Name", style: { margin: "0 5px 0 0" } },
+        panel7
       );
-      var TrackName = new TextBox({ value: "RD", width: "5em" }).placeAt(panel7);
+      var TrackName = new TextBox({ value: "RD", width: "5em" }).placeAt(
+        panel7
+      );
 
       this.sampleIndex = sampleIndex;
       // these names correspond with the SimpleFeature source field in
@@ -238,10 +248,11 @@ define([
       new Button({
         label: "Submit",
         onClick: () => {
-
           const conf = this.browser.resolveUrl(
             // this.browser.config.dataRoot + "/gc/" + "hg19.100000.gc",
-            this.browser.config.baseUrl + "/plugins/CNVpytorVCF/test/data/gc/" + "hg19.100000.gc",
+            this.browser.config.baseUrl +
+              "/plugins/CNVpytorVCF/test/data/gc/" +
+              "hg19.100000.gc"
           );
 
           // if they passed a URL, use the search box
@@ -274,7 +285,7 @@ define([
             var storeConf = {
               browser: this.browser,
               refSeq: this.browser.refSeq,
-              binSize : binSize.value,
+              binSize: binSize.value,
               sample: +this.sampleIndex.value || 0,
               type: "CNVpytorVCF/Store/SeqFeature/RDSegmentation",
               gcContent: conf,
@@ -290,7 +301,7 @@ define([
           var storeName = this.browser.addStoreConfig(undefined, storeConf);
           storeConf.name = storeName;
 
-          track_name = TrackName.value ? TrackName.value : 'RD';
+          track_name = TrackName.value ? TrackName.value : "RD";
 
           var searchTrackConfig = {
             type: "MultiBigWig/View/Track/MultiWiggle/MultiXYPlot",
@@ -330,7 +341,7 @@ define([
           setTimeout(function () {
             dialog.destroyRecursive();
           }, 500);
-        }),
+        })
       );
     },
 
@@ -344,19 +355,19 @@ define([
       var subcontainer = dojo.create(
         "div",
         { style: { padding: "20px" } },
-        container,
+        container
       );
       const flex = dojo.create(
         "div",
         { style: { display: "flex", border: "1px solid black" } },
-        subcontainer,
+        subcontainer
       );
 
       const panel1 = dojo.create("div", { style: { padding: "10px" } }, flex);
       dojo.create(
         "p",
         { innerHTML: "Option 1: URL for a VCF.gz file (tabixed VCF)" },
-        panel1,
+        panel1
       );
 
       var searchBox = new TextBox().placeAt(panel1);
@@ -368,14 +379,13 @@ define([
           innerHTML:
             "Option 2: Open VCF.gz and VCF.gz.tbi file from local computer",
         },
-        panel2,
+        panel2
       );
       var fileBox = dojo.create(
         "input",
         { type: "file", multiple: "multiple" },
-        panel2,
+        panel2
       );
-
 
       this.searchBox = searchBox;
       this.fileBox = fileBox;
@@ -383,29 +393,29 @@ define([
       // sample index selection
       const flex4 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel4 = dojo.create("div", { style: { padding: "1px" } }, flex4);
 
       dojo.create(
         "snan",
-        { innerHTML: "Sample index", style: {margin: "0 5px 0 0"} },
-        panel4,
+        { innerHTML: "Sample index", style: { margin: "0 5px 0 0" } },
+        panel4
       );
       var sampleIndex = new TextBox({ value: 0, width: "5em" }).placeAt(panel4);
 
       dojo.create(
         "snan",
-        { innerHTML: "or ", style: {margin: "0 5px 0 5px"} },
-        panel4,
+        { innerHTML: "or ", style: { margin: "0 5px 0 5px" } },
+        panel4
       );
 
       // select sample panel
       const flex5 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel5 = dojo.create("div", { style: { padding: "1px" } }, flex5);
 
@@ -415,12 +425,16 @@ define([
           let tabixFile;
           if (this.searchBox.value) {
             tabixFile = new TabixIndexedFile({
-              filehandle: new XHRBlob(this.searchBox.value, {
-                expectRanges: true,
-              }),
-              tbiFilehandle: new XHRBlob(this.searchBox.value + ".tbi", {
-                expectRanges: true,
-              }),
+              filehandle: new BlobFilehandleWrapper(
+                new XHRBlob(this.searchBox.value, {
+                  expectRanges: true,
+                })
+              ),
+              tbiFilehandle: new BlobFilehandleWrapper(
+                new XHRBlob(this.searchBox.value + ".tbi", {
+                  expectRanges: true,
+                })
+              ),
             });
           } else if (this.fileBox.files.length) {
             let tbi = 0;
@@ -436,20 +450,21 @@ define([
             }
             tabixFile = new TabixIndexedFile({
               filehandle: new BlobFilehandleWrapper(
-                new FileBlob(this.fileBox.files[vcf]),
+                new FileBlob(this.fileBox.files[vcf])
               ),
               tbiFilehandle: new BlobFilehandleWrapper(
-                new FileBlob(this.fileBox.files[tbi]),
+                new FileBlob(this.fileBox.files[tbi])
               ),
             });
           }
 
           if (tabixFile) {
             let vcfParser = new VCF({ header: await tabixFile.getHeader() });
+            panel5.innerHTML = "";
             dojo.create(
               "span",
-              { innerHTML: "Select sample:", style: {margin: "0 5px 0 0"}},
-              panel5,
+              { innerHTML: "Select sample:", style: { margin: "0 5px 0 0" } },
+              panel5
             );
 
             this.sampleSelectBox = new Select({
@@ -464,21 +479,22 @@ define([
         },
       }).placeAt(panel4);
 
-
       // Bin size selection
 
       const flex6 = dojo.create(
         "div",
-        { style: { display: "flex", padding: "1px"} },
-        subcontainer,
+        { style: { display: "flex", padding: "1px" } },
+        subcontainer
       );
       const panel6 = dojo.create("div", { style: { padding: "1px" } }, flex6);
       dojo.create(
         "snan",
-        { innerHTML: "Bin Size", style: {margin: "0 5px 0 0"} },
-        panel6,
+        { innerHTML: "Bin Size", style: { margin: "0 5px 0 0" } },
+        panel6
       );
-      var binSize = new TextBox({ value: 100000, width: "5em" }).placeAt(panel6);
+      var binSize = new TextBox({ value: 100000, width: "5em" }).placeAt(
+        panel6
+      );
 
       this.sampleIndex = sampleIndex;
       this.binSize = binSize;
@@ -496,7 +512,7 @@ define([
         label: "Submit",
         onClick: () => {
           const conf = this.browser.resolveUrl(
-            this.browser.config.dataRoot + "/gc/" + "hg19.100000.gc",
+            this.browser.config.dataRoot + "/gc/" + "hg19.100000.gc"
           );
 
           const sampleIndex = this.sampleSelectBox
@@ -591,7 +607,7 @@ define([
           setTimeout(function () {
             dialog.destroyRecursive();
           }, 500);
-        }),
+        })
       );
     },
   });


### PR DESCRIPTION
@arpanda 

This PR adds a warning if the VCF file unzips to larger than 500MB in memory. See screenshot here

![localhost_jbrowse__data=plugins%2FCNVpytorVCF%2Ftest%2Fdata loc=chr1%3A38645475 38697108 tracks=DNA%2Csearch_track_0 highlight=](https://user-images.githubusercontent.com/6511937/106520896-afaca300-649a-11eb-85c3-c9138a97ae0c.png)

This PR also fixes a bug with detecting sample names when pasting a URL into the dialog box

It could be possible to process the file line by line using streaming but there are two challenges

1) the line-by-line parser from node.js module, readline, does not browserify easily
2) the zlib module, pako, fails on bgzip files which is what most tabix vcf files are

It could still be possible to make this work but will need work

See https://github.com/cmdcolin/CNVpytorVCF/tree/buffer for a starter on processing chunks of data instead of unzipping it entirely into memory. It fails eventually because of (2) and doesn't not do line by line because of (1) but again, more work could maybe make this work

